### PR TITLE
Safety check to prevent crash on macOS when IOHIDManagerCopyDevices() returns NULL

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -407,6 +407,8 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	/* Get a list of the Devices */
 	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
+	if (device_set == NULL)
+		return NULL;
 
 	/* Convert the list into a C array so we can iterate easily. */
 	num_devices = CFSetGetCount(device_set);
@@ -1081,6 +1083,8 @@ int main(void)
 	IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
 
 	CFSetRef device_set = IOHIDManagerCopyDevices(mgr);
+	if (device_set == NULL)
+		return 0;
 
 	CFIndex num_devices = CFSetGetCount(device_set);
 	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));


### PR DESCRIPTION
from: https://github.com/signal11/hidapi/pull/359

solves bug: https://github.com/paritytech/parity/issues/7542